### PR TITLE
Update Jekyll and stylesheets to work on modern Ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,11 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.9.0"
+gem "jekyll", "~> 4.4", ">= 4.4.1"
 
 gem "kramdown-parser-gfm", "~>1.1"
-gem "jemoji", "~> 0.12"
-gem "webrick", "~> 1.8.1"
+gem "jemoji", "~> 0.13"
+gem 'webrick', '~> 1.9', '>= 1.9.1'
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
@@ -20,16 +20,14 @@ gem "webrick", "~> 1.8.1"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-feed", "~> 0.17"
   gem "jekyll-github-metadata"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
-install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
-  gem "tzinfo", "~> 1.2"
-  gem "tzinfo-data"
-end
+gem 'tzinfo', '~> 2.0', '>= 2.0.6', platforms: :windows
+gem "tzinfo-data", platforms: :windows
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
+gem "wdm", "~> 0.2.0", platforms: :windows

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -1,3 +1,4 @@
+@use "colours";
 // For the bottom aligned footer
 html, body {
 	height: 100%;
@@ -14,16 +15,16 @@ footer {
 }
 
 body {
-	color: $main-color;
-	background-color: $main-bg;
+	color: colours.$main-color;
+	background-color: colours.$main-bg;
 }
 
 h1, h2, h3, h4, h5, h6 {
-	color: $header-color;
+	color: colours.$header-color;
 }
 
 h1, h2 {
-	border-bottom: 1px solid $borders;
+	border-bottom: 1px solid colours.$borders;
 }
 
 h1 {
@@ -35,15 +36,15 @@ hr {
 }
 
 blockquote {
-	color: $blockquote-color;
+	color: colours.$blockquote-color;
 	margin-bottom: 20px;
 	padding: 0 0 0 20px;
-	border-left: 3px solid $borders;
+	border-left: 3px solid colours.$borders;
 }
 
 :not(pre) > code, pre {
-	color: $code-color;
-	background-color: $code-bg;
+	color: colours.$code-color;
+	background-color: colours.$code-bg;
 	padding: 3px;
 	border-radius: 0.25rem;
 }
@@ -67,15 +68,15 @@ a > code {
 }
 
 div.language-bash pre.highlight code::before {
-	content: "$ ";
-	color: $code-light;
+	content: "colours.$ ";
+	color: colours.$code-light;
 }
 
 // .a is for making other things look like <a>s
 a, .a {
 	text-decoration: none;
 	text-decoration-thickness: 1px;
-	color: $a-color;
+	color: colours.$a-color;
 	cursor: pointer;
 }
 a:hover, .a:hover {
@@ -98,7 +99,7 @@ footer a:hover {
 
 small {
 	font-size: 75%;
-	color: $small-color;
+	color: colours.$small-color;
 }
 
 img {
@@ -130,57 +131,57 @@ div .btn-primary:hover {
 
 // Override bootstraps primary color
 .bg-primary {
-	background-color: $primary!important;
+	background-color: colours.$primary!important;
 }
 .btn-primary, .btn-primary:focus {
-	color: $nav-link-color;
-	background-color: $primary!important;
-	border-color: $primary!important;
+	color: colours.$nav-link-color;
+	background-color: colours.$primary!important;
+	border-color: colours.$primary!important;
 }
 .btn-primary:hover, .btn-primary:active {
-	color: $nav-link-color!important;
+	color: colours.$nav-link-color!important;
 	opacity: 0.8;
 }
 .btn-outline-primary {
-	color: $primary;
-	border-color: $primary;
+	color: colours.$primary;
+	border-color: colours.$primary;
 }
 .btn-outline-primary:hover, .btn-outline-primary:active {
-	background-color: $primary!important;
-	border-color: $primary!important;
+	background-color: colours.$primary!important;
+	border-color: colours.$primary!important;
 }
 .text-primary {
-	background-color: $primary!important;
+	background-color: colours.$primary!important;
 }
 
 // Override the secondary text color
 .btn-outline-secondary {
-	color: $main-color;
+	color: colours.$main-color;
 }
 
 .alert-secondary {
-	color: $code-color;
-	background-color: $alert-secondary-bg;
-	border-color: $alert-secondary-border;
+	color: colours.$code-color;
+	background-color: colours.$alert-secondary-bg;
+	border-color: colours.$alert-secondary-border;
 }
 
 // Override the dark text too
 .text-dark {
-	color: $dark!important;
+	color: colours.$dark!important;
 }
 // text-dark that I dont override
 .text-dark-always {
-	color: $dark-always!important;
+	color: colours.$dark-always!important;
 }
 
 // And the light bg
 .bg-light {
-	background-color: $light!important;
-	border-color: $light-border!important;
+	background-color: colours.$light!important;
+	border-color: colours.$light-border!important;
 }
 
 .bg-light::placeholder {
-	color: $light-placeholder;
+	color: colours.$light-placeholder;
 }
 
 // No underline on navbar links
@@ -195,18 +196,18 @@ div .btn-primary:hover {
 
 // Override nav-link color
 .navbar .nav-link {
-	color: $nav-link-color!important;
+	color: colours.$nav-link-color!important;
 }
 .navbar .nav-link:hover {
-	color: $nav-link-color-hover!important;
+	color: colours.$nav-link-color-hover!important;
 }
 
 // And the active nav-link color
 .navbar .nav-link.active {
-	color: $nav-link-color-active!important;
+	color: colours.$nav-link-color-active!important;
 }
 .navbar .nav-link.active:hover {
-	color: $nav-link-color-hover!important;
+	color: colours.$nav-link-color-hover!important;
 }
 
 // Fixes for navbar on older browsers
@@ -228,7 +229,7 @@ html[dir=rtl] .navbar-toggler {
 
 // Make dropdowns site-colored and animated
 .dropdown-menu, .dropdown .hover-content {
-	background-color: $primary;
+	background-color: colours.$primary;
 	-webkit-transition: 300ms ease;
 	transition: 300ms ease;
 	display: block;
@@ -255,14 +256,14 @@ html[dir=rtl] .navbar-toggler {
 }
 
 .dropdown-item {
-	color: $nav-link-color;
+	color: colours.$nav-link-color;
 }
 .dropdown-item.active {
 	background-color: unset;
 }
 .dropdown-item:hover, .dropdown-item:active, .dropdown-item:focus {
-	background-color: $dropdown-item-bg-hover;
-	color: $nav-link-color-hover;
+	background-color: colours.$dropdown-item-bg-hover;
+	color: colours.$nav-link-color-hover;
 }
 
 // Make images smaller
@@ -334,33 +335,33 @@ html[dir=rtl] {
 
 // Input box
 .input-group-text {
-	color: $light-placeholder;
-	background-color: $light;
-	border-color: $light-border;
+	color: colours.$light-placeholder;
+	background-color: colours.$light;
+	border-color: colours.$light-border;
 }
 .form-control, .form-control:focus, .form-control::placeholder {
-	color: $main-color;
-	background-color: $light;
-	border-color: $light-border;
+	color: colours.$main-color;
+	background-color: colours.$light;
+	border-color: colours.$light-border;
 }
 .form-control:disabled {
-	background-color: $light-disabled;
+	background-color: colours.$light-disabled;
 }
 
 .input-group-text, .form-control::-webkit-file-upload-button {
-	background-color: $alert-secondary-bg;
-	color: $main-color;
+	background-color: colours.$alert-secondary-bg;
+	color: colours.$main-color;
 }
 .form-control:hover:not(:disabled):not([readonly])::-webkit-file-upload-button {
-	background-color: $alert-secondary-border;
+	background-color: colours.$alert-secondary-border;
 }
 // Safari is dumb and doesn't let the Firefox one be with the others
 .form-control::file-selector-button {
-	background-color: $alert-secondary-bg;
-	color: $main-color;
+	background-color: colours.$alert-secondary-bg;
+	color: colours.$main-color;
 }
 .form-control:hover:not(:disabled):not([readonly])::file-selector-button {
-	background-color: $alert-secondary-border;
+	background-color: colours.$alert-secondary-border;
 }
 
 // Cards
@@ -393,11 +394,11 @@ html[dir=rtl] {
 }
 
 .card {
-	background-color: $card-background;
+	background-color: colours.$card-background;
 }
 
 .card-header, .card-footer {
-	background-color: $card-edges-background;
+	background-color: colours.$card-edges-background;
 }
 
 .pointer {
@@ -405,7 +406,7 @@ html[dir=rtl] {
 }
 
 .card-qr {
-	color: $small-color;
+	color: colours.$small-color;
 }
 
 .card-qr:hover {
@@ -417,17 +418,17 @@ html[dir=rtl] {
 }
 
 .modal-content {
-	background-color: $main-bg;
+	background-color: colours.$main-bg;
 }
 .modal-header {
-	border-bottom: $modal-borders;
+	border-bottom: colours.$modal-borders;
 }
 .modal-footer {
-	border-top: $modal-borders;
+	border-top: colours.$modal-borders;
 }
 
 .carousel-label {
-	background-color: $carousel-caption-bg;
+	background-color: colours.$carousel-caption-bg;
 	border-radius: 10px;
 }
 
@@ -456,27 +457,27 @@ h1:hover, h2:hover, h3:hover, h4:hover, h5:hover, h6:hover {
 
 // File forms
 .form-control {
-	background-color: $main-bg;
-	color: $main-color;
-	border: 1px solid $borders;
+	background-color: colours.$main-bg;
+	color: colours.$main-color;
+	border: 1px solid colours.$borders;
 }
 
 .input-group-text, .form-control::-webkit-file-upload-button {
-	background-color: $secondary-bg;
-	color: $main-color;
-	border: 1px solid $borders;
+	background-color: colours.$secondary-bg;
+	color: colours.$main-color;
+	border: 1px solid colours.$borders;
 }
 .form-control:hover:not(:disabled):not([readonly])::-webkit-file-upload-button {
-	background-color: $code-bg;
+	background-color: colours.$code-bg;
 }
 // Safari is dumb and don't let the Firefox one be with the others
 .form-control::file-selector-button {
-	background-color: $secondary-bg;
-	color: $main-color;
-	border: 1px solid $borders;
+	background-color: colours.$secondary-bg;
+	color: colours.$main-color;
+	border: 1px solid colours.$borders;
 }
 .form-control:hover:not(:disabled):not([readonly])::file-selector-button {
-	background-color: $code-bg;
+	background-color: colours.$code-bg;
 }
 
 // Tables
@@ -488,14 +489,14 @@ table th {
 }
 table th, table td {
 	padding: 6px 13px;
-	border: 1px solid $light-borders;
+	border: 1px solid colours.$light-borders;
 }
 table tr:nth-child(2n) {
-	background-color: $table-alt-bg;
+	background-color: colours.$table-alt-bg;
 }
 // Fix bootstrap messing up the th bottom borders and dark mode text
 .table>:not(:last-child)>:last-child>* {
-	border-bottom-color: $light-borders;
+	border-bottom-color: colours.$light-borders;
 }
 
 .table {
@@ -507,12 +508,12 @@ kbd {
 	padding: 3px 6px;
 	font: 11px SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
 	line-height: 10px;
-	color: $main-color;
+	color: colours.$main-color;
 	vertical-align: middle;
-	background-color: $kbd-bg;
-	border: 1px solid $kbd-border;
+	background-color: colours.$kbd-bg;
+	border: 1px solid colours.$kbd-border;
 	border-radius: 6px;
-	box-shadow: inset 0 -1px 0 $kbd-border;
+	box-shadow: inset 0 -1px 0 colours.$kbd-border;
 }
 
 kbd.l {
@@ -532,7 +533,7 @@ kbd.face {
 // Sidebar
 .sidebar-container {
 	font-size: 0.9rem;
-	border: 1px solid $borders;
+	border: 1px solid colours.$borders;
 }
 
 .sidebar-container ul {
@@ -549,7 +550,7 @@ kbd.face {
 }
 
 .details-content {
-	background-color: $details-bg;
+	background-color: colours.$details-bg;
 	margin-left: 1rem;
 	padding: 0.5rem;
 	border-radius: 0.5rem;
@@ -599,7 +600,7 @@ a.footnote::after {
 	flex-wrap: wrap;
 
 	.tab-link {
-		border: 1px solid $borders;
+		border: 1px solid colours.$borders;
 		border-bottom-width: 0;
 		padding: 0.5rem 1rem;
 		transition: 150ms ease;
@@ -650,7 +651,7 @@ a.footnote::after {
 		padding: 1rem 1rem 0 1rem;
 		margin-bottom: 1rem;
 		width: 100%;
-		border: 1px solid $borders;
+		border: 1px solid colours.$borders;
 
 		@media screen and (min-width: 576px) {
 			border-radius: 0 0.25rem 0.25rem 0.25rem;
@@ -671,13 +672,13 @@ a.footnote::after {
 	}
 
 	input:checked + .tab-link:not(:hover):not(:active):not(:focus) {
-		background-color: $borders;
-		border-color: $borders;
+		background-color: colours.$borders;
+		border-color: colours.$borders;
 	}
 	.tab-link:hover, .tab-link:active, .tab-link:focus {
-		color: $borders-hover-color;
-		background-color: $borders-hover;
-		border-color: $borders-hover;
+		color: colours.$borders-hover-color;
+		background-color: colours.$borders-hover;
+		border-color: colours.$borders-hover;
 	}
 }
 
@@ -690,7 +691,7 @@ a.footnote::after {
 		margin-bottom: 0;
 
 		> summary.accordion-button {
-			color: $header-color;
+			color: colours.$header-color;
 
 			// Padding for chevron
 			html[dir=ltr] & {
@@ -718,13 +719,13 @@ a.footnote::after {
 		}
 
 		> .faq {
-			background-color: $active-accordian-bg-color;
+			background-color: colours.$active-accordian-bg-color;
 		}
 
 		&[open] {
 			summary.accordion-button {
-				color: $active-accordian-header-color;
-				background-color: $active-accordian-header-bg-color;
+				color: colours.$active-accordian-header-color;
+				background-color: colours.$active-accordian-header-bg-color;
 
 				&::after {
 					background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%230c63e4'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");

--- a/_sass/colours.scss
+++ b/_sass/colours.scss
@@ -1,0 +1,48 @@
+/// Variables
+// Main contents
+$main-bg: #fff !default;
+$main-color: #222 !default;
+$secondary-bg: #e9e9e9 !default;
+$header-color: #222 !default;
+$borders: #bbb !default;
+$borders-hover: #666 !default;
+$borders-hover-color: #fff !default;
+$light-borders: #dee2e6 !default;
+$blockquote-color: #666 !default;
+$code-bg: #ccc6 !default;
+$code-color: #333 !default;
+$code-light: #999 !default;
+$a-color: #0366d6 !default;
+$small-color: gray !default;
+$textarea-bg: $main-bg !default;
+$textarea-color: #000 !default;
+$carousel-caption-bg: #fffb !default;
+$table-alt-bg: #f3f3f3 !default;
+$kbd-bg: #fafafa !default;
+$kbd-border: #ddd !default;
+$alert-secondary-bg: #e9e9e9 !default;
+$alert-secondary-border: #bbb !default;
+$details-bg: #f9f9f9 !default;
+$active-accordian-bg-color: #fcfcfc !default;
+$active-accordian-header-color: #0c63e4 !default;
+$active-accordian-header-bg-color: #e7f1ff !default;
+
+// Cards
+$card-background: #fff !default;
+$card-edges-background: rgba(0,0,0,.03) !default;
+
+// Modal
+$modal-borders: 1px solid #dee2e6 !default;
+
+// Nav
+$nav-link-color: rgba(0, 0, 0, 0.7) !default;
+$nav-link-color-hover: rgba(0, 0, 0, 0.5) !default;
+$nav-link-color-active: rgba(0, 0, 0, 1) !default;
+$dropdown-item-bg-hover: rgba(0, 0, 0, 0.2) !default;
+$primary: #f2acae !default;
+$dark: #343a40 !default;
+$dark-always: #343a40 !default;
+$light: #f8f9fa !default;
+$light-border: #ced4da !default;
+$light-placeholder: darkgray !default;
+$light-disabled: #e9ecef !default;

--- a/assets/css/dark.scss
+++ b/assets/css/dark.scss
@@ -1,57 +1,57 @@
 ---
 ---
 
-/// Variables
-// Main contents
-$main-bg: #333;
-$main-color: #ccc;
-$secondary-bg: #4f4f4f;
-$header-color: #ddd;
-$borders: #555;
-$borders-hover: #777;
-$borders-hover-color: #fff;
-$light-borders: #444;
-$blockquote-color: #999;
-$code-bg: #5559;
-$code-color: #ddd;
-$code-light: #999;
-$a-color: #58a6ff;
-$small-color: gray;
-$textarea-bg: #303030;
-$textarea-color: #fff;
-$carousel-caption-bg: #333b;
-$table-alt-bg: #303030;
-$kbd-bg: #666;
-$kbd-border: #444;
-$alert-secondary-bg: #444;
-$alert-secondary-border: #2f2f2f;
-$details-bg: #3f3f3f;
-$active-accordian-bg-color: #393939;
-$active-accordian-header-color: #222;
-$active-accordian-header-bg-color: #4477ac;
+@use "colours" with (
+	// Main contents
+	$main-bg: #333,
+	$main-color: #ccc,
+	$secondary-bg: #4f4f4f,
+	$header-color: #ddd,
+	$borders: #555,
+	$borders-hover: #777,
+	$borders-hover-color: #fff,
+	$light-borders: #444,
+	$blockquote-color: #999,
+	$code-bg: #5559,
+	$code-color: #ddd,
+	$code-light: #999,
+	$a-color: #58a6ff,
+	$small-color: gray,
+	$textarea-bg: #303030,
+	$textarea-color: #fff,
+	$carousel-caption-bg: #333b,
+	$table-alt-bg: #303030,
+	$kbd-bg: #666,
+	$kbd-border: #444,
+	$alert-secondary-bg: #444,
+	$alert-secondary-border: #2f2f2f,
+	$details-bg: #3f3f3f,
+	$active-accordian-bg-color: #393939,
+	$active-accordian-header-color: #222,
+	$active-accordian-header-bg-color: #4477ac,
 
-// Cards
-$card-background: #444;
-$card-edges-background: rgba(0, 0, 0, 0.15);
+	// Cards
+	$card-background: #444,
+	$card-edges-background: rgba(0, 0, 0, 0.15),
 
-// Modal
-$modal-borders: 1px solid rgba(0, 0, 0, 0.2);
+	// Modal
+	$modal-borders: 1px solid rgba(0, 0, 0, 0.2),
 
-// Nav
-$nav-link-color: rgba(0, 0, 0, 0.7);
-$nav-link-color-hover: rgba(0, 0, 0, 0.5);
-$nav-link-color-active: rgba(0, 0, 0, 1);
-$dropdown-item-bg-hover: rgba(0, 0, 0, 0.2);
-$primary: #b55356;
-$dark: #f8f9fa;
-$dark-always: #343a40;
-$light: #3f3f3f;
-$light-border: #292929;
-$light-placeholder: #999;
-$light-disabled: #303030;
-
+	// Nav
+	$nav-link-color: rgba(0, 0, 0, 0.7),
+	$nav-link-color-hover: rgba(0, 0, 0, 0.5),
+	$nav-link-color-active: rgba(0, 0, 0, 1),
+	$dropdown-item-bg-hover: rgba(0, 0, 0, 0.2),
+	$primary: #b55356,
+	$dark: #f8f9fa,
+	$dark-always: #343a40,
+	$light: #3f3f3f,
+	$light-border: #292929,
+	$light-placeholder: #999,
+	$light-disabled: #303030
+);
 /// Import base style
-@import "base";
+@use "base";
 
 /// CSS Overrides
 // Override FAQ accordian chevron color

--- a/assets/css/light.scss
+++ b/assets/css/light.scss
@@ -1,57 +1,57 @@
 ---
 ---
 
-/// Variables
-// Main contents
-$main-bg: #fff;
-$main-color: #222;
-$secondary-bg: #e9e9e9;
-$header-color: #222;
-$borders: #bbb;
-$borders-hover: #666;
-$borders-hover-color: #fff;
-$light-borders: #dee2e6;
-$blockquote-color: #666;
-$code-bg: #ccc6;
-$code-color: #333;
-$code-light: #999;
-$a-color: #0366d6;
-$small-color: gray;
-$textarea-bg: $main-bg;
-$textarea-color: #000;
-$carousel-caption-bg: #fffb;
-$table-alt-bg: #f3f3f3;
-$kbd-bg: #fafafa;
-$kbd-border: #ddd;
-$alert-secondary-bg: #e9e9e9;
-$alert-secondary-border: #bbb;
-$details-bg: #f9f9f9;
-$active-accordian-bg-color: #fcfcfc;
-$active-accordian-header-color: #0c63e4;
-$active-accordian-header-bg-color: #e7f1ff;
+@use "colours" with (
+	// Main contents
+	$main-bg: #fff,
+	$main-color: #222,
+	$secondary-bg: #e9e9e9,
+	$header-color: #222,
+	$borders: #bbb,
+	$borders-hover: #666,
+	$borders-hover-color: #fff,
+	$light-borders: #dee2e6,
+	$blockquote-color: #666,
+	$code-bg: #ccc6,
+	$code-color: #333,
+	$code-light: #999,
+	$a-color: #0366d6,
+	$small-color: gray,
+	$textarea-bg: #fff,
+	$textarea-color: #000,
+	$carousel-caption-bg: #fffb,
+	$table-alt-bg: #f3f3f3,
+	$kbd-bg: #fafafa,
+	$kbd-border: #ddd,
+	$alert-secondary-bg: #e9e9e9,
+	$alert-secondary-border: #bbb,
+	$details-bg: #f9f9f9,
+	$active-accordian-bg-color: #fcfcfc,
+	$active-accordian-header-color: #0c63e4,
+	$active-accordian-header-bg-color: #e7f1ff,
 
-// Cards
-$card-background: $main-bg;
-$card-edges-background: rgba(0,0,0,.03);
+	// Cards
+	$card-background: #fff,
+	$card-edges-background: rgba(0,0,0,.03),
 
-// Modal
-$modal-borders: 1px solid #dee2e6;
+	// Modal
+	$modal-borders: 1px solid #dee2e6,
 
-// Nav
-$nav-link-color: rgba(0, 0, 0, 0.7);
-$nav-link-color-hover: rgba(0, 0, 0, 0.5);
-$nav-link-color-active: rgba(0, 0, 0, 1);
-$dropdown-item-bg-hover: rgba(0, 0, 0, 0.2);
-$primary: {{ page.color | default: site.color }};
-$dark: #343a40;
-$dark-always: #343a40;
-$light: #f8f9fa;
-$light-border: #ced4da;
-$light-placeholder: darkgray;
-$light-disabled: #e9ecef;
-
+	// Nav
+	$nav-link-color: rgba(0, 0, 0, 0.7),
+	$nav-link-color-hover: rgba(0, 0, 0, 0.5),
+	$nav-link-color-active: rgba(0, 0, 0, 1),
+	$dropdown-item-bg-hover: rgba(0, 0, 0, 0.2),
+	$primary: {{ page.color | default: site.color }},
+	$dark: #343a40,
+	$dark-always: #343a40,
+	$light: #f8f9fa,
+	$light-border: #ced4da,
+	$light-placeholder: darkgray,
+	$light-disabled: #e9ecef
+);
 /// Import base style
-@import "base";
+@use "base";
 
 /// CSS Overrides
 .carousel-dark-when-light .carousel-control-next-icon, .carousel-dark-when-light .carousel-control-prev-icon {


### PR DESCRIPTION
Ruby 3.4.0 removed some of the gems required by Jekyll from it's standard libraries. While fixed in Jekyll 4.3(?)'s gemfile, it means that older versions of Jekyll, such as 3.9.0 in this repo, cannot build without missing gem errors on 3.4.0+.

I have gone ahead and updated Jekyll so that the site can be built on modern Ruby versions. I also updated some of the other gems, as well as properly limiting wdm and tzinfo to Windows only - previously this didn't seem to work as those gems would attempt to install on non-Windows platforms.

The newer Jekyll updates also came with the newer SASS version, where ruby-sass was deprecated in favour of sass-embedded. This comes with the downside of `@import` rules also being deprecated and soon to be removed. Replacements for it are `@use` and `@forward`, but they do not work in the same way, and tweaks have to be made to the base style for it to work properly.

It seems to be now that you declare your variables as being default variables, then you can use the `@use` rule to modify their values. e.g.
```css
// base.scss
$main-bg: null !default;
body {
  background-color: $main-bg;
}
```
```css
// style.scss
@use "base" with (
  $main-bg: #fff;
);
```
```css
// result
body {
  background-color: #fff;
}
```
I have updated the base style to account for `@import` being removed soon. I have made the colour variables their own module, and set their values in the dark/light stylesheets. The site style is generated as it was before, though this time there is no warnings about import being deprecated. I'm not sure how well I explained all that though because I'm still trying to wrap my head around it :P